### PR TITLE
added Unwrap, IsOk, IsErr

### DIFF
--- a/eh.go
+++ b/eh.go
@@ -38,6 +38,16 @@ func (r Result[T]) Eh() T {
 	return r.Ok
 }
 
+// IsOk returns true when result has no error and otherwise false
+func (r Result[T]) IsOk() bool {
+	return r.Err == nil
+}
+
+// IsErr returns true when result has error and otherwise false
+func (r Result[T]) IsErr() bool {
+	return r.Err != nil
+}
+
 // MustUnwrap returns the Ok value or panics if there is an error.
 func (r Result[T]) MustUnwrap() T {
 	if r.Err != nil {
@@ -52,6 +62,11 @@ func (r Result[T]) MustUnwrapErr() error {
 		panic("expected the result to contain error")
 	}
 	return r.Err
+}
+
+// Unwrap returns a value and an error
+func (r Result[T]) Unwrap() (T, error) {
+	return r.Ok, r.Err
 }
 
 // ehError is used to wrap any errors that are raised because of calling

--- a/eh_test.go
+++ b/eh_test.go
@@ -133,14 +133,14 @@ func example(aFile string) (res Result[[]byte]) {
 
 func TestExample(t *testing.T) {
 	res := example("README.md")
-	if res.Err != nil {
+	if res.IsErr() {
 		t.Fatalf("Err is not nil %+v", res)
 	}
 }
 
 func TestExampleFail(t *testing.T) {
 	res := example("non-existing-file")
-	if res.Err == nil {
+	if res.IsOk() {
 		t.Fatalf("Err should be nil %+v", res)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/olevski/eh
 
-go 1.20
+go 1.21


### PR DESCRIPTION
There are situations where `eh.Result` needs to be unpacked into the conventional (value, error) format in order to work with code from other libraries. This pull request introduces an `Unwrap` function to accomplish that. Additionally, two helper functions, `IsOk` and `IsErr`, have been added to enhance the readability of using `eh.Result` with `if` statements.