### PR TITLE
Introducing more error handling methods Fallback, CatchError, and adding other utils

### DIFF
--- a/eh.go
+++ b/eh.go
@@ -15,6 +15,10 @@
 // Package eh (escapehatch) provides Rust-like error handling in Go.
 package eh
 
+import (
+	"errors"
+)
+
 // Result represents a struct that contains an error in the Err field
 // or the valid output from some action in the Ok field. Since Results are copied it is
 // reccomended that the Ok value be a pointer.
@@ -27,6 +31,23 @@ type Result[T any] struct {
 // convert the output of any function that returns a value and an error.
 func NewResult[T any](val T, err error) Result[T] {
 	return Result[T]{val, err}
+}
+
+// FromFailable creates a Result from an error. This is useful when you need to
+// execute a function that doesn't return a value but may result in failure.
+//
+// Example:
+//
+//	func example() (r eh.Result[string]) {
+//		eh.EscapeHatch(&r)
+//
+//		var data string
+//		eh.FromFailable(json.Unmarshal([]byte{}, &data)).Eh()
+//
+//		return eh.Result[string]{Ok: data}
+//	}
+func FromFailable(err error) Result[any] {
+	return Result[any]{0, err}
 }
 
 // Eh checks if there is an error in the result and if so then it will
@@ -64,8 +85,23 @@ func (r Result[T]) MustUnwrapErr() error {
 	return r.Err
 }
 
-// Unwrap returns a value and an error
+// Unwrap method returns a value and an error
 func (r Result[T]) Unwrap() (T, error) {
+	return r.Ok, r.Err
+}
+
+// Unwrap function unwraps a Result into a value and an error, making
+// it useful for implementing inline callbacks.
+//
+// Example:
+//
+//	// from this:
+//	newIterable := someIterable.Map(func (v Result[T]) {
+//		 return v.Unwrap()
+//	 })
+//	// to this:
+//	newIterable := someIterable.Map(eh.Unwrap[T])
+func Unwrap[T any](r Result[T]) (T, error) {
 	return r.Ok, r.Err
 }
 
@@ -87,5 +123,114 @@ func EscapeHatch[T any](res *Result[T]) {
 			panic(r)
 		}
 		*res = Result[T]{Err: err.error}
+	}
+}
+
+// EscapeHatchErr is similarly to the `EscapeHatch`, with the difference
+// that it is designed for implementing methods that must conform to return
+// signatures of `(value, error)` or `(error)`, such as overriding a method
+// in a superclass.
+//
+// Example:
+//
+//	func ExampleRequestHandler(c *Context) (val string, err error) {
+//		defer eh.EscapeHatchErr(&err)	// adapt to (val, error)
+//
+//		successVal := eh.NewResult(failableFunc()).Eh()
+//
+//		return successVal, nil
+//	}
+func EscapeHatchErr(err *error) {
+	res := FromFailable(*err)
+	defer func() {
+		_, *err = res.Unwrap()
+	}()
+	defer EscapeHatch(&res)
+	if r := recover(); r != nil {
+		panic(r)
+	}
+}
+
+// HandlerError is similar to `Fallback`, with the difference that it
+// executes a handler with the fallback value returned instead of directly
+// specifies the value. Furthermore, you can call `.Eh()` within the
+// handler, which may succeed or rethrow a new error to later handlers.
+//
+// Example:
+//
+//	func main() {
+//		var WhenGetFromDBError error
+//		var WhenGetFromRemoteError error
+//		var WhenGetFromInMemoryError error
+//		func Example() (r eh.Result[string]) {
+//				// Escape if error is not handled
+//				defer eh.EscapeHatch(&r)
+//				// Run error handler when previous `defer` rethrows error
+//				defer eh.CatchError(&r, func(_ error) {
+//					return eh.NewResult(GetFromRemote()).Eh()
+//				}, WhenGetFromDBError)
+//				// Run error handler when error is `WhenGetFromInMemoryError`
+//				defer eh.CatchError(&r, func(_ error) {
+//					return eh.NewResult(GetFromDb()).Eh()
+//				}, WhenGetFromInMemoryError)
+//				successVal := eh.NewResult(GetFromInMemory()).Eh()
+//				return eh.Result[string]{Ok: successVal}
+//			}
+//	}
+func CatchError[T any](res *Result[T], catcher func(error) T, when ...error) {
+	defer func() {
+		if res.IsOk() {
+			return
+		}
+
+		err := res.MustUnwrapErr()
+		// Passing nil `when` means use orElse for any error
+		if when == nil {
+			*res = Result[T]{Ok: catcher(err)}
+			return
+		}
+		for _, target := range when {
+			if !errors.Is(err, target) {
+				continue
+			}
+			// Use fallback value if the result error matches the target error, otherwise leave the result untouched
+			*res = Result[T]{Ok: catcher(err)}
+			break
+		}
+	}()
+	defer EscapeHatch(res)
+	if r := recover(); r != nil {
+		panic(r)
+	}
+}
+
+// Fallback allows for the substitution of an error with a default value.
+// It is optional to specify the types of errors for which the default value
+// will be used. If no errors are specified, the default value will be used
+// as a fallback for all errors.
+//
+// Example:
+//
+//	func main() {
+//		var WhenGetFromDBError error
+//		var WhenGetFromRemoteError error
+//		var WhenGetFromInMemoryError error
+//		func Example() (r eh.Result[string]) {
+//				// Escape when error is not handled
+//				defer eh.EscapeHatch(&r)
+//				// Fallback to default value
+//				defer eh.Fallback(&r, "default value",
+//					WhenGetFromDBError,
+//					WhenGetFromRemoteError,
+//					WhenGetFromInMemoryError)
+//
+//				successVal := eh.NewResult(FailableApiToGetData()).Eh()
+//				return eh.Result[string]{Ok: successVal}
+//			}
+//	}
+func Fallback[T any](res *Result[T], fallback T, when ...error) {
+	defer CatchError(res, func(_ error) T { return fallback }, when...)
+	if r := recover(); r != nil {
+		panic(r)
 	}
 }


### PR DESCRIPTION
This PR introduces additional error handling methods that further enhance the existing "Rust-like" Result pattern. The `.Eh()` method is designed to halt function execution upon encountering an error, causing the error to bubble up through the Go `defer` mechanism. This PR leverages this mechanism to enhance error handling with a clearer approach "success logic flows down, error handling flows up." 

With new deferred function `Fallback` and `CatchError`, we could turn this:

```go
var InMemoryErr = errors.New("inmemory record not found")
var DbNotFoundError = errors.New("db record not found")
var ApiNotFound = errors.New("api record not found")

func tryFindFromMemory() (string, error) {return "", InMemoryErr }
func tryFindFromDb() (string, error) {return "", DbNotFoundError }
func tryFindFromApi() (string, error) {return "", ApiNotFound }

func example() (string, error) {
  val, err := tryFindFromMemory()
  if err == nil {
    return val  // success value returns here
  }
  if errors.Is(err, InMemoryErr) {
    val, err = tryFindFromDb()
    if err == nil {
      return val
    }
  }
  if errors.Is(err, DbNotFoundError) {
    val, err = tryFindFromApi()
    if err == nil {
      return val
    }
  }
  if errors.Is(err, ApiNotFound) {
    return "I'm default value for ApiNotFound"
  }
  return "I'm default value for other errors"
}

```
into this
```go
var InMemoryErr = errors.New("inmemory record not found")
var DbNotFoundError = errors.New("db record not found")
var ApiNotFound = errors.New("api record not found")

func tryFindFromMemory() (string, error) {return "", InMemoryErr }
func tryFindFromDb() (string, error) {return "", DbNotFoundError }
func tryFindFromApi() (string, error) {return "", ApiNotFound }

func example() (res eh.Result[string]) {
   eh.Fallback(&res, "I'm default value for other errors")
   eh.Fallback(&res, "I'm default value for ApiNotFound", ApiNotFound)
   eh.CatchError(&res, func(error) {
     return eh.NewResult(mayFailWithErr3()).Eh()
   }, DbNotFoundError)
   eh.CatchError(&res, func(error) {
     return eh.NewResult(tryFindFromDb()).Eh()
   }, InMemoryErr)

  successVal := eh.NewResult(tryFindFromMemory()).Eh()
  return eh.Result[string]{Ok: successVal}
}

```

Additionally, this PR adds a new constructor `FromFailable` and a defer function `EscapeHatchErr`.

EscapeHatchErr is similarly to the `EscapeHatch`, with the difference
that it is designed for implementing methods that must conform to return
signatures of `(value, error)` or `(error)`, such as overriding a method
in a superclass.

```go
func ExampleRequestHandler(c *Context) (val string, err error) {
  defer eh.EscapeHatchErr(&err)	// adapt to (val, error)

  successVal := eh.NewResult(failableFunc()).Eh()

  return successVal, nil
}
```

FromFailable creates a Result from an error. This is useful when you need to
execute a function that doesn't return a value but may result in failure.

```go
func example() (r eh.Result[string]) {
  eh.EscapeHatch(&r)

  var data string
  eh.FromFailable(json.Unmarshal([]byte{}, &data)).Eh()

  return eh.Result[string]{Ok: data}
}
```

Feel free to rename any of these functions as you see fit if you like to merge this PR.